### PR TITLE
大佬，发现您的项目引入了com.fasterxml.jackson.core:jackson-databind@2.0.0组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.rokai</groupId>
@@ -62,7 +60,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.0.0</version>
+      <version>2.9.10.8</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：FasterXML jackson-databind 代码问题漏洞
缺陷组件：com.fasterxml.jackson.core:jackson-databind@2.0.0
漏洞编号：CVE-2020-8840
漏洞描述：FasterXML Jackson是美国FasterXML公司的一款适用于Java的数据处理工具。jackson-databind是其中的一个具有数据绑定功能的组件。
FasterXML jackson-databind 2.0.0版本至2.9.10.2版本中存在代码问题漏洞，该漏洞源于程序缺少xbean-reflect/JNDI黑名单类。攻击者可利用该漏洞执行代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-13183
影响范围：(∞, 2.6.7.4)
最小修复版本：2.9.10.8
缺陷组件引入路径：com.rokai:CRM@3.0->com.fasterxml.jackson.core:jackson-databind@2.0.0
```
另外我运行这个项目时，IDE的安全插件提示还有68个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pa0971